### PR TITLE
Collect argument values for an option of type string-array.

### DIFF
--- a/Command.cs
+++ b/Command.cs
@@ -103,7 +103,14 @@ namespace NCommander
                                 i++;
 
                                 object value = option.Type.ConvertAction(args[i]);
-                                convertedArgs[option.Name] = value;
+                                if (option.Type == ParameterType.StringArray)
+                                {
+                                    if (convertedArgs[option.Name] == null)
+                                        convertedArgs[option.Name] = new List<string>();
+                                    ((List<string>)convertedArgs[option.Name]).Add((string)value);
+                                }
+                                else
+                                    convertedArgs[option.Name] = value;
                             }
                             break;
                         }
@@ -146,6 +153,13 @@ namespace NCommander
                 !Params[p].IsOptional)
             {
                 throw new NotEnoughArgumentsForParameterException(Params[p]);
+            }
+
+            foreach (var option in Options)
+            {
+                if (option.Type == ParameterType.StringArray)
+                    convertedArgs[option.Name] =
+                        ((List<string>)convertedArgs[option.Name]).ToArray();
             }
 
             return convertedArgs;

--- a/NCommanderTests/CommandTest.cs
+++ b/NCommanderTests/CommandTest.cs
@@ -282,6 +282,36 @@ namespace NCommanderTests
             Assert.AreEqual("arg1", a[0]);
             Assert.AreEqual("arg4", a[1]);
         }
+
+        [Test]
+        public void OptionStringArrayCanBeUsedManyTimesConsumingOneArgEach()
+        {
+            // given
+            var command = new Command
+            {
+                Options = new[]
+                {
+                    new Option
+                    {
+                        Name = "opt",
+                        Type = ParameterType.StringArray
+                    },
+                }
+            };
+            Dictionary<string, object> convertedArgs = null;
+            command.ExecuteDelegate = (x) => convertedArgs = x;
+
+            // when
+            command.Execute(new[] {"--opt", "value1", "--opt", "value2"});
+
+            // then
+            Assert.IsNotNull(convertedArgs);
+            Assert.AreEqual(1, convertedArgs.Count);
+            Assert.IsTrue(convertedArgs.ContainsKey("opt"));
+            Assert.IsInstanceOf<string[]>(convertedArgs["opt"]);
+            Assert.AreEqual(new string[] {"value1", "value2"},
+                convertedArgs["opt"]);
+        }
     }
 }
 

--- a/ParameterType.cs
+++ b/ParameterType.cs
@@ -32,7 +32,7 @@ namespace NCommander
                     "No conversion is performed. A parameter of this type can only " +
                     "appear at the end of the parameter list.",
                 outputType: typeof(string[]),
-                convertAction: (x) => null
+                convertAction: (x) => x
             );
 
 


### PR DESCRIPTION
This PR adds the ability to process `Option`s of type `StringArray`. The normal argument processing proceed as usual; the option will consume a single argument. However, the option can be specified multiple times, and each time the value is appended to a list instead of replacing the previous value. All values so supplied will be passed to the `Command` as a `string[]`.

Thus, `--opt value1 --opt value2` will result in `new string[] { "value1", "value2"}`.